### PR TITLE
[WIP] Weighted affinities for the spark executors

### DIFF
--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -240,6 +240,9 @@ type SparkApplicationSpec struct {
 	Deps Dependencies `json:"deps,omitempty"`
 	// RestartPolicy defines the policy on if and in which conditions the controller should restart an application.
 	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
+	// WeightedAffinities contains the weights of the labels to decide about the labels to put on the executor pods
+	// +optional
+	WeightedAffinities map[string]float64 `json:"weightedAffinities,omitempty"`
 	// NodeSelector is the Kubernetes node selector to be added to the driver and executor pods.
 	// This field is mutually exclusive with nodeSelector at podSpec level (driver or executor).
 	// This field will be deprecated in future versions (at SparkApplicationSpec level).

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/zz_generated.deepcopy.go
@@ -709,6 +709,13 @@ func (in *SparkApplicationSpec) DeepCopyInto(out *SparkApplicationSpec) {
 	in.Executor.DeepCopyInto(&out.Executor)
 	in.Deps.DeepCopyInto(&out.Deps)
 	in.RestartPolicy.DeepCopyInto(&out.RestartPolicy)
+	if in.WeightedAffinities != nil {
+		in, out := &in.WeightedAffinities, &out.WeightedAffinities
+		*out = make(map[string]float64, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -508,7 +508,7 @@ func addWeightedAffinities(pod *corev1.Pod, app *v1beta2.SparkApplication) *patc
 		glog.Infof("Discovered label for the weighted affinity: %s. Weight: %f", label, weight)
 	}
 
-	if totalWeight != 0 {
+	if totalWeight != 1.0 {
 		glog.Warningf("the sum of the weights for the weighted affinities must be 1.0")
 		return nil
 	}

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -508,8 +508,8 @@ func addWeightedAffinities(pod *corev1.Pod, app *v1beta2.SparkApplication) *patc
 		glog.Infof("Discovered label for the weighted affinity: %s. Weight: %f", label, weight)
 	}
 
-	if totalWeight > 1.0 || totalWeight < 0 {
-		glog.Warningf("the sum of the weights for the weighted affinities must be in the interval [0,1]")
+	if totalWeight != 0 {
+		glog.Warningf("the sum of the weights for the weighted affinities must be 1.0")
 		return nil
 	}
 

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -401,7 +401,9 @@ func TestPatchSparkPod_WeightedAffinities(t *testing.T) {
 
 	// be sure affinity is set
 	assert.True(t, modifiedPod.Spec.Affinity != nil)
-	assert.True(t, modifiedPod.Spec.Affinity.NodeAffinity != nil) // PreferredDuringSchedulingIgnoredDuringExecution
+	assert.True(t, modifiedPod.Spec.Affinity.NodeAffinity != nil)
+
+	/* uncomment this when the PreferredDuringSchedulingIgnoredDuringExecution is used
 	assert.True(t, modifiedPod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil)
 	assert.True(t, len(modifiedPod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) == 1)
 
@@ -409,6 +411,16 @@ func TestPatchSparkPod_WeightedAffinities(t *testing.T) {
 	schedulingTerm := modifiedPod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
 	assert.True(t, schedulingTerm.Preference.MatchExpressions != nil)
 	matchExpressions := schedulingTerm.Preference.MatchExpressions
+	assert.True(t, len(matchExpressions) == 1)
+	nodeSelectorRequirements := matchExpressions[0]
+	*/
+
+	// test for RequiredDuringSchedulingIgnoredDuringExecution policy
+	assert.True(t, modifiedPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil)
+	nodeSelectorTerms := modifiedPod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	assert.True(t, nodeSelectorTerms != nil)
+	assert.True(t, len(nodeSelectorTerms) == 1)
+	matchExpressions := nodeSelectorTerms[0].MatchExpressions
 	assert.True(t, len(matchExpressions) == 1)
 	nodeSelectorRequirements := matchExpressions[0]
 


### PR DESCRIPTION
This PR introduces the following:
* a new field in the SparkApplication CRD called `weightedAffinities`. It is a map where each key is the applied affinity label and the value is the weight used to decide if it is must be applied or not
* all the logic  is wrapped in the mutating webhook of the operator (so the operator must be deployed with it enabled)
* this logic is only applied to executor pods. The driver pod is skipped (so a normal affinity can be applied there)
* the used affinity logic is **RequiredDuringSchedulingIgnoredDuringExecution**, but if you uncomment the relevant section you can switch to **PreferredDuringSchedulingIgnoredDuringExecution** (this policy also requires a weight parameter that regulates the strictness of the scheduling)

An example config would be:
```bash
weightedAffinities:
    "on-demand-instance": 0.7
    "spot-instance": 0.3
```

This would put the affinity label **on-demand-instance** on the 70% of the executors pods and the other label on the remaining 30%